### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 **See the [documentation website](https://trevordmiller.com/projects/nova) for more information**
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/3owRGftAkghuGdjHaa955zEJ/agarrharr/nova-gnome-terminal'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/3owRGftAkghuGdjHaa955zEJ/agarrharr/nova-gnome-terminal.svg' /></a>
+


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8